### PR TITLE
Add config parameters to elasticsearch index functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,14 @@ var search = new FirebaseSearch(usersRef, {
   algolia: algoliaConfig
 }, 'users');
 
-search.elasticsearch.firebase.start();
+// Optional elasticsearch configuration settings
+var config = {
+  added: { /* settings passed into elasticsearch client create function */ },
+  changed: { /* settings passed into elasticsearch client update function  */ },
+  deleted: { /* settings passed into elasticsearch client delete function  */ }
+};
+
+search.elasticsearch.firebase.start(config);
 search.algolia.firebase.start();
 ```
 
@@ -225,8 +232,17 @@ search.elasticsearch.firebase.build()
 
 Starts listening to Firebase records additions, changes and removals, syncing Elasticsearch appropriately
 
+Optional `config` is used to pass custom parameters to ElasticSearch's [create](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-create), [update](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-update), and [delete](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-delete) function calls.
+
 ```javascript
-search.elasticsearch.firebase.start()
+// Optional elasticsearch configuration settings
+var config = {
+  added: { /* settings passed into elasticsearch client create function */ },
+  changed: { /* settings passed into elasticsearch client update function  */ },
+  deleted: { /* settings passed into elasticsearch client delete function  */ }
+};
+
+search.elasticsearch.firebase.start(config)
   .then(function () {
     console.log('Syncing Elasticsearch with Firebase');
   })

--- a/firebase-search.js
+++ b/firebase-search.js
@@ -243,7 +243,10 @@ function setPrototype(firebaseSearch) {
             });
           });
       },
-      start: function () {
+      start: function (config) {
+        // set default value for config to an empty object if not provided
+        config = typeof config !== 'undefined' ? config : {};
+
         return new Promise(function (resolve, reject) {
           var ref = firebaseSearch.ref;
           var started;
@@ -255,28 +258,43 @@ function setPrototype(firebaseSearch) {
               } else {
                 firebaseSearch.fire('elasticsearch_child_added', addKeyToSnap(snap));
                 // firebaseSearch.log('elasticsearch_child_added', snap.key);
-                firebaseSearch.elasticsearch.create({
-                  id: snap.key,
-                  body: snap.val()
-                });
+                firebaseSearch.elasticsearch.create(
+                  _.merge({},
+                    config.added,
+                    {
+                      id: snap.key,
+                      body: snap.val()
+                    }
+                  )
+                );
               }
             },
             child_changed: function (snap) {
               firebaseSearch.fire('elasticsearch_child_changed', addKeyToSnap(snap));
               // firebaseSearch.log('elasticsearch_child_changed', snap.key);
-              firebaseSearch.elasticsearch.update({
-                id: snap.key,
-                body: {
-                  doc: snap.val()
-                }
-              });
+              firebaseSearch.elasticsearch.update(
+                _.merge({},
+                  config.changed,
+                  {
+                    id: snap.key,
+                    body: {
+                      doc: snap.val()
+                    }
+                  }
+                )
+              );
             },
             child_removed: function (snap) {
               firebaseSearch.fire('elasticsearch_child_removed', addKeyToSnap(snap));
               // firebaseSearch.log('elasticsearch_child_removed', snap.key);
-              firebaseSearch.elasticsearch.delete({
-                id: snap.key
-              });
+              firebaseSearch.elasticsearch.delete(
+                _.merge({},
+                  config.deleted,
+                  {
+                    id: snap.key
+                  }
+                )
+              );
             }
           };
           firebaseSearch.elasticsearch.listeningRefs = {


### PR DESCRIPTION
Per #6 - this allows users to pass in configuration parameters for add/update/delete when they run `FirebaseSearch.prototype.elasticsearch.firebase.start()`

I hope my documentation is straightforward enough - there's an awful lot of config variables flying around in there 😉 
cc @bonitis